### PR TITLE
change module and directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ Just add the following to your `router.ex`:
     post "/login", Addict.Controller, :login
 ```
 
-And use `AddictAuthenticated` plug to validate requests on your controllers:
+And use `Addict.Plugs.Authenticated` plug to validate requests on your controllers:
 ```
 defmodule MyAwesomeApp.PageController do
   use Phoenix.Controller
 
-  plug AddictAuthenticated when action in [:foobar]
+  plug Addict.Plugs.Authenticated when action in [:foobar]
   plug :action
 
   def foobar(conn, _params) do

--- a/lib/addict/controller.ex
+++ b/lib/addict/controller.ex
@@ -1,6 +1,6 @@
 defmodule Addict.Controller do
   use Phoenix.Controller
-  alias AddictManagerInteractor, as: AddictManager
+  alias Addict.ManagerInteractor, as: AddictManager
 
   plug :action
 

--- a/lib/addict/email_gateway.ex
+++ b/lib/addict/email_gateway.ex
@@ -1,5 +1,5 @@
 defmodule Addict.EmailGateway do
-  def send_welcome_email(user, mailer \\ Addict.MailgunMailer) do
+  def send_welcome_email(user, mailer \\ Addict.Mailers.Mailgun) do
     mailer.send_email_to_user "#{user.username} <#{user.email}>",
                        Application.get_env(:addict, :register_from_email),
                        Application.get_env(:addict, :register_subject),

--- a/lib/addict/mailers/mailgun.ex
+++ b/lib/addict/mailers/mailgun.ex
@@ -1,4 +1,4 @@
-defmodule Addict.MailgunMailer do
+defmodule Addict.Mailers.Mailgun do
   require Logger
   use Mailgun.Client, domain: Application.get_env(:addict, :mailgun_domain),
                       key: Application.get_env(:addict, :mailgun_key)

--- a/lib/addict/manager_interactor.ex
+++ b/lib/addict/manager_interactor.ex
@@ -1,13 +1,13 @@
-defmodule AddictManagerInteractor do
+defmodule Addict.ManagerInteractor do
   require Logger
 
-  def create(email, username, password, repo \\ AddictRepository, mailer \\ Addict.EmailGateway) do
+  def create(email, username, password, repo \\ Addict.Repository, mailer \\ Addict.EmailGateway) do
     generate_password(password)
     |> create_username(email, username, repo)
     |> send_welcome_email(mailer)
   end
 
-  def verify_password(email, password, repo \\ AddictRepository) do
+  def verify_password(email, password, repo \\ Addict.Repository) do
     user = repo.find_by_email email
 
     if valid_credentials(user, password) do

--- a/lib/addict/plugs/authenticated.ex
+++ b/lib/addict/plugs/authenticated.ex
@@ -1,4 +1,4 @@
-defmodule AddictAuthenticated do
+defmodule Addict.Plugs.Authenticated do
   import Plug.Conn
   use Phoenix.Controller
 

--- a/lib/addict/repository.ex
+++ b/lib/addict/repository.ex
@@ -1,4 +1,4 @@
-defmodule AddictRepository do
+defmodule Addict.Repository do
   require Logger
 
   import Ecto.Query


### PR DESCRIPTION
Move all modules to under Addict namespace.
This change can avoid namespace collisions and
make addict follow the custom of mix project.

This is a breaking change.
I think that the modules naming needs more discussion.
