### PR TITLE
add AuthenticatedTest

### DIFF
--- a/lib/addict/plugs/authenticated.ex
+++ b/lib/addict/plugs/authenticated.ex
@@ -22,7 +22,7 @@ defmodule Addict.Plugs.Authenticated do
   redirect to `/error`.
   """
   def call(conn, _) do
-    fetch_session(conn)
+    conn = fetch_session(conn)
 
     if get_session(conn, :logged_in) do
       Map.put(conn, :current_user, get_session(conn, :current_user))
@@ -32,7 +32,7 @@ defmodule Addict.Plugs.Authenticated do
   end
 
   def not_logged_in_url do
-    Application.get_env(:addict, :not_logged_in_url) || "/error"
+    Application.get_env(:addict, :not_logged_in_url, "/error")
   end
 
 end

--- a/lib/addict/plugs/authenticated.ex
+++ b/lib/addict/plugs/authenticated.ex
@@ -14,8 +14,8 @@ defmodule Addict.Plugs.Authenticated do
   @doc """
   Call represents the use of the plug itself.
 
-  When called, it will populate `conn` with the `current_user`, so it is
-  possible to always retrieve the user via `conn[:current_user]`.
+  When called, it will assign `current_user` to `conn`, so it is
+  possible to always retrieve the user via `conn.assigns.current_user`.
 
   In case the user is not logged in, it will redirect the request to
   the Application :addict :not_logged_in_url page. If none is defined, it will
@@ -25,7 +25,7 @@ defmodule Addict.Plugs.Authenticated do
     conn = fetch_session(conn)
 
     if get_session(conn, :logged_in) do
-      Map.put(conn, :current_user, get_session(conn, :current_user))
+      assign(conn, :current_user, get_session(conn, :current_user))
     else
       conn |> redirect(to: not_logged_in_url) |> halt
     end

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,15 @@ defmodule Addict.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :bcrypt]]
+    [applications: applications(Mix.env)]
+  end
+
+  defp applications(:test) do
+    [:plug] ++ applications(:prod)
+  end
+
+  defp applications(_) do
+    [:logger, :bcrypt]
   end
 
   defp deps(:test) do

--- a/test/plugs/authenticated_test.exs
+++ b/test/plugs/authenticated_test.exs
@@ -1,0 +1,49 @@
+defmodule AuthenticatedTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Addict.Plugs.Authenticated, as: Auth
+
+  @session_opts Plug.Session.init [
+    store: :cookie,
+    key: "_test",
+    encryption_salt: "abcdefgh",
+    signing_salt: "abcdefgh"
+  ]
+
+  @authenticated_opts Auth.init []
+
+  setup_all do
+    conn = conn(:get, "/")
+      |> Map.put(:secret_key_base, String.duplicate("a", 64))
+      |> Plug.Session.call(@session_opts)
+      |> fetch_session
+
+    {:ok, %{conn: conn}}
+  end
+
+  test "not_logged_in_url" do
+    assert Auth.not_logged_in_url == "/error"
+  end
+
+  test "assign current_user when logged in", context do
+    conn = context.conn
+      |> put_session(:logged_in, true)
+      |> put_session(:current_user, "bob")
+
+    refute Map.has_key?(conn.assigns, :current_user)
+
+    conn = Auth.call(conn, @authenticated_opts)
+    assert conn.assigns.current_user == "bob"
+  end
+
+  test "redirect when not logged in", context do
+    conn = context.conn
+      |> put_session(:logged_in, false)
+      |> Auth.call(@authenticated_opts)
+
+    assert conn.halted
+    assert conn.status in 300..399
+    assert get_resp_header(conn, "Location") == [Auth.not_logged_in_url]
+  end
+end


### PR DESCRIPTION
I'm sorry this pull-request has many purposes.

First, a bug fix. line 25 on authenticated.ex, `fetch_session(conn)` has no side-effect so its return value have to be bound to `conn`.
Second, make it use `conn.assigns` to have current user. I think this is best practice to keep something in `conn`.
Third, add some tests for `Authenticated` plug. with that, `application` in mix.exs should take `Mix.env`.

And I have a question. Do you have any plan to utilize the session `:logged_in`?
If it is here only for checking the user is logged in or not, we can do it with only `:current_user` like following.

``` ex
case get_session(conn, :current_user) do
  nil  -> redirect(to: ...)
  user -> assign(conn, :current_user, user)
end
```
