### PR TITLE
Removing redundant 'debug' output

### DIFF
--- a/lib/addict/manager_interactor.ex
+++ b/lib/addict/manager_interactor.ex
@@ -86,7 +86,6 @@ defmodule Addict.ManagerInteractor do
   end
 
   defp reset_user_password(user, hash, repo) do
-    IO.inspect user
     repo.change_password(user, hash)
   end
 


### PR DESCRIPTION
I noticed this while doing a code read, I'm assuming it's not a feature :smile:
