### PR TITLE
Move use Phoenix.Controller expression from BaseController to Controller

### DIFF
--- a/lib/addict/controller.ex
+++ b/lib/addict/controller.ex
@@ -7,11 +7,9 @@ defmodule Addict.BaseController do
 
   defmacro __using__(_) do
     quote do
-      use Phoenix.Controller
 
       @manager Application.get_env(:addict, :manager) || Addict.ManagerInteractor
       alias Addict.SessionInteractor
-      plug :action
 
       @doc """
         Entry point for registering new users.
@@ -92,6 +90,8 @@ defmodule Addict.Controller do
   @moduledoc """
    Default controller used by Addict
    """
-
+  use Phoenix.Controller
+  plug :action
   use Addict.BaseController
+
 end


### PR DESCRIPTION
this makes it more explicit that to "extend" the BaseController, you still have to `use` Phoenix.Controller and `plug` action, so that if you would composite your controller with others using `use` they wouldn't conflit.
 I will update doc's later
