### PR TITLE
Update comeinon dependency from 0.2.2 to 0.4.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Addict.Mixfile do
     [{:cowboy, "~> 1.0"},
      {:phoenix, ">= 0.8.0"},
      {:ecto, ">= 0.6.0"},
-     {:comeonin, "~> 0.2.2" },
+     {:comeonin, "~> 0.4" },
      {:mailgun, "~> 0.0.2"},
      {:earmark, "~> 0.1", only: :docs},
      {:ex_doc, "~> 0.7.1", only: :docs}]


### PR DESCRIPTION
Changes since 0.2.2:
- Updated pbkdf2_sha512 to prevent users from calling hashpass without a salt.
- Updated bcrypt to version 1.5.2.
- Added configuration options for number of log_rounds, or rounds.
