### PR TITLE
Add all dependencies to applications so Exrm works

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Addict.Mixfile do
   end
 
   defp applications(_) do
-    [:logger]
+    [:phoenix, :ecto, :comeonin, :mailgun, :logger]
   end
 
   defp deps do


### PR DESCRIPTION
This adds all dependencies to applications so releasing with exrm works (see http://www.phoenixframework.org/v0.11.0/docs/advanced-deployment)
