### PR TITLE
Removed username

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ The user model must have at least the following schema:
 ```
   id serial primary key,
   email varchar(200),
-  username varchar(200),
   hash varchar(130),
   recovery_hash varchar(130),
   CONSTRAINT u_constraint UNIQUE (email)

--- a/example_app/lib/presenters/email_presenter.ex
+++ b/example_app/lib/presenters/email_presenter.ex
@@ -1,7 +1,7 @@
 defmodule ExampleApp.Presenters.EmailPresenter do
   def register_template(user) do
     """
-    <p><b>Hi #{user.username},</b></p>
+    <p><b>Hi #{user.email},</b></p>
     <p>Thanks for joining!</p>
     <p>Cheers!</p>
     <p></p>
@@ -11,7 +11,7 @@ defmodule ExampleApp.Presenters.EmailPresenter do
 
   def password_recovery_template(user) do
     """
-    <p><b>Hi #{user.username},</b></p>
+    <p><b>Hi #{user.email},</b></p>
     <p> It seems you've lost your password! </p>
     <p> Use this token <b>#{user.recovery_hash}"</b> to recover your password.</p>
     <p>

--- a/example_app/priv/repo/migrations/20150221030445_add_users_table.exs
+++ b/example_app/priv/repo/migrations/20150221030445_add_users_table.exs
@@ -4,7 +4,6 @@ defmodule Coffee.Repo.Migrations.CreateUsers do
   def up do
     create table(:users) do
       add :email,         :string, size: 200
-      add :username,      :string, size: 200
       add :hash,          :string, size: 130
       add :recovery_hash, :string, size: 130
 

--- a/example_app/web/models/user.ex
+++ b/example_app/web/models/user.ex
@@ -4,7 +4,6 @@ defmodule ExampleApp.Models.User do
     field :email, :string
     field :hash, :string
     field :recovery_hash, :string
-    field :username, :string
     timestamps
   end
 

--- a/example_app/web/templates/page/index.html.eex
+++ b/example_app/web/templates/page/index.html.eex
@@ -9,9 +9,6 @@
   <div class="col-lg-6">
     <h4>Register</h4>
     <div>
-      <input id="txt-register-username" type="text" placeholder="username">
-    </div>
-    <div>
       <input id="txt-register-email" type="text" placeholder="email">
     </div>
     <div>
@@ -85,13 +82,11 @@
   $(document).ready(function () {
     $('#btn-register').click(function() {
       var email = $('#txt-register-email').val();
-      var username = $('#txt-register-username').val();
       var password = $('#txt-register-password').val();
 
       $.post('/register', {
         email: email,
         password: password,
-        username: username
       })
       .then(function(data) {
         alert(data.message);

--- a/lib/addict/controller.ex
+++ b/lib/addict/controller.ex
@@ -14,7 +14,7 @@ defmodule Addict.BaseController do
       @doc """
         Entry point for registering new users.
 
-       `params` needs to include email, password and username.
+       `params` needs to include email and password.
         Returns a JSON response in the format `{message: text, user: %User{}}` with status `201` for
         successful creation, or `400` for when an error occurs.
         On success, it also logs the new user in.

--- a/lib/addict/email_gateway.ex
+++ b/lib/addict/email_gateway.ex
@@ -4,14 +4,14 @@ defmodule Addict.EmailGateway do
   mail library. For now, only Mailgun is supported.
   """
   def send_welcome_email(user, mailer \\ Addict.Mailers.Mailgun) do
-    mailer.send_email_to_user "#{user.username} <#{user.email}>",
+    mailer.send_email_to_user "<#{user.email}>",
                        Application.get_env(:addict, :register_from_email),
                        Application.get_env(:addict, :register_subject),
                        Application.get_env(:addict, :email_templates).register_template(user)
   end
 
   def send_password_recovery_email(user, mailer \\ Addict.Mailers.Mailgun) do
-    mailer.send_email_to_user "#{user.username} <#{user.email}>",
+    mailer.send_email_to_user "<#{user.email}>",
                        Application.get_env(:addict, :password_recover_from_email),
                        Application.get_env(:addict, :password_recover_subject),
                        Application.get_env(:addict, :email_templates).password_recovery_template(user)

--- a/lib/addict/interactors/addict_manager_interactor.ex
+++ b/lib/addict/interactors/addict_manager_interactor.ex
@@ -21,13 +21,13 @@ defmodule Addict.BaseManagerInteractor do
         Creates a user on the database and sends the welcoming e-mail via the defined
         `mailer`.
 
-        Required fields in `user_params` `Dict` are: `email`, `password`, `username`.
+        Required fields in `user_params` `Dict` are: `email`, `password`.
       """
       def create(user_params, repo \\ Addict.Repository, mailer \\ Addict.EmailGateway, password_interactor \\ Addict.PasswordInteractor) do
         validate_params(user_params)
         |> (fn (params) -> params["password"] end).()
         |> password_interactor.generate_hash
-        |> create_username(user_params, repo)
+        |> scrub_password(user_params, repo)
         |> send_welcome_email(mailer)
       end
 
@@ -106,14 +106,13 @@ defmodule Addict.BaseManagerInteractor do
 
       defp validate_params(user_params) do
         case is_nil(user_params["email"])
-             or is_nil(user_params["password"])
-             or is_nil(user_params["username"]) do
+             or is_nil(user_params["password"]) do
                false -> user_params
-               true -> throw "Unable to create user, invalid hash. Required params: email, password, username"
+               true -> throw "Unable to create user, invalid hash. Required params: email, password."
              end
       end
 
-      defp create_username(hash, user_params, repo) do
+      defp scrub_password(hash, user_params, repo) do
         user_params = Map.delete(user_params, "password")
         |> Map.put("hash", hash)
         repo.create(user_params)

--- a/test/manager_interactor_test.exs
+++ b/test/manager_interactor_test.exs
@@ -3,13 +3,13 @@ defmodule Addict.ManagerInteractorTest do
   alias Addict.ManagerInteractor, as: Interactor
 
   test "creates a user" do
-    user_params = %{"email" => "test@example.com", "password" => "password", "username" => "test"}
+    user_params = %{"email" => "test@example.com", "password" => "password"}
     assert Interactor.create(user_params, RepoStub, MailerStub, PasswordInteractorStub) == {:ok, %{email: "test@example.com"}}
   end
 
   test "validates for invalid params" do
     user_params = %{}
-    assert catch_throw(Interactor.create(user_params, RepoStub, MailerStub)) == "Unable to create user, invalid hash. Required params: email, password, username"
+    assert catch_throw(Interactor.create(user_params, RepoStub, MailerStub)) == "Unable to create user, invalid hash. Required params: email, password."
   end
 
   test "validates for nil params" do


### PR DESCRIPTION
Would you consider dropping the username requirement? It is a breaking change. 
##### Motivation

Username doesn't serve any vital role within the user management system and removing it simplifies core user management and helps enforce a separation of concerns (which IMHO is a great thing). 
<br/>
##### But wait, what if I love usernames?

Likewise, it's easy enough for users to create an associated profile or account table which contains information like username, first_name, last_name, etc. This is a little more work but it keeps the system very concise and also allows users to implement the controllers around the additional functionality however they want without worrying about having to hack into the core user management.
