### PR TITLE
Strip private metadata from user session

### DIFF
--- a/lib/addict/interactors/session_interactor.ex
+++ b/lib/addict/interactors/session_interactor.ex
@@ -71,8 +71,7 @@ defmodule Addict.SessionInteractor do
 
   defp sanitize_user(user) do
     user
-    |> Map.delete :hash
-    |> Map.delete :recovery_hash
+    |> Map.drop [:hash, :recovery_hash, :__meta__, :__struct__]
   end
 
 end


### PR DESCRIPTION
Probably shouldn't send `__meta__` or `__struct__` down the pipe to the
client.

Closes #50.
