### PR TITLE
Resolve mix build warnings about unsafe variables

### DIFF
--- a/lib/addict/interactors/validate_password.ex
+++ b/lib/addict/interactors/validate_password.ex
@@ -11,7 +11,11 @@ defmodule Addict.Interactors.ValidatePassword do
   end
 
   def call(changeset, strategies) do
-    if Enum.count(strategies) == 0, do: strategies = [:default]
+    strategies = 
+      case Enum.count(strategies) do
+        0 -> [:default]
+        _ -> strategies
+      end
 
     strategies
     |> Enum.reduce(changeset, fn (strategy, acc) ->

--- a/lib/addict/mix/generate_configs.ex
+++ b/lib/addict/mix/generate_configs.ex
@@ -14,19 +14,25 @@ defmodule Mix.Tasks.Addict.Generate.Configs do
       Mix.shell.info "[o] Generating Addict configuration"
 
       guessed = Mix.shell.yes? "Is your application root module #{base_module}?"
-      base_module = unless guessed do
-        Mix.shell.prompt("Please insert your application root module:") |> String.rstrip
-      end
+      base_module = 
+        case guessed do
+          true -> base_module
+          false -> Mix.shell.prompt("Please insert your application root module:") |> String.rstrip
+        end
 
       guessed = Mix.shell.yes? "Is your Ecto Repository module #{repo}?"
-      repo = unless guessed do
-        Mix.shell.prompt("Please insert your Ecto Repository module:") |> String.rstrip
-      end
+      repo = 
+        case guessed do
+          true -> repo
+          false -> Mix.shell.prompt("Please insert your Ecto Repository module:") |> String.rstrip
+        end
 
       guessed = Mix.shell.yes? "Is your User Schema module #{user_schema}?"
-      user_schema = unless guessed do
-        Mix.shell.prompt("Please insert your User Schema module:") |> String.rstrip
-      end
+      user_schema = 
+        case guessed do
+          true -> user_schema
+          false -> Mix.shell.prompt("Please insert your User Schema module:") |> String.rstrip
+        end
 
       use_mailgun = Mix.shell.yes? "Will you be using Mailgun?"
       mailgun_domain = 

--- a/lib/addict/mix/generate_configs.ex
+++ b/lib/addict/mix/generate_configs.ex
@@ -10,31 +10,36 @@ defmodule Mix.Tasks.Addict.Generate.Configs do
       base_module = guess_application_name
       user_schema = "#{base_module}.User"
       repo        = "#{base_module}.Repo"
-      mailgun_domain = ""
-      mailgun_api_key = ""
 
       Mix.shell.info "[o] Generating Addict configuration"
 
       guessed = Mix.shell.yes? "Is your application root module #{base_module}?"
-      unless guessed do
-        base_module = Mix.shell.prompt("Please insert your application root module:") |> String.rstrip
+      base_module = unless guessed do
+        Mix.shell.prompt("Please insert your application root module:") |> String.rstrip
       end
 
       guessed = Mix.shell.yes? "Is your Ecto Repository module #{repo}?"
-      unless guessed do
-        repo = Mix.shell.prompt("Please insert your Ecto Repository module:") |> String.rstrip
+      repo = unless guessed do
+        Mix.shell.prompt("Please insert your Ecto Repository module:") |> String.rstrip
       end
 
       guessed = Mix.shell.yes? "Is your User Schema module #{user_schema}?"
-      unless guessed do
-        user_schema = Mix.shell.prompt("Please insert your User Schema module:") |> String.rstrip
+      user_schema = unless guessed do
+        Mix.shell.prompt("Please insert your User Schema module:") |> String.rstrip
       end
 
       use_mailgun = Mix.shell.yes? "Will you be using Mailgun?"
-      if use_mailgun do
-        mailgun_domain  = Mix.shell.prompt("Please insert your Mailgun domain: (e.g.: https://api.mailgun.net/v3/sandbox123456.mailgun.org)") |> String.rstrip
-        mailgun_api_key = Mix.shell.prompt("Please insert your Mailgun API key:") |> String.rstrip
-      end
+      mailgun_domain = 
+        case use_mailgun do
+          true -> Mix.shell.prompt("Please insert your Mailgun domain: (e.g.: https://api.mailgun.net/v3/sandbox123456.mailgun.org)") |> String.rstrip
+          false -> ""
+        end
+
+      mailgun_api_key = 
+        case use_mailgun do 
+          true -> Mix.shell.prompt("Please insert your Mailgun API key:") |> String.rstrip
+          false -> ""
+        end
 
       add_addict_configs(configs_path, user_schema, repo, use_mailgun, mailgun_domain, mailgun_api_key)
     end
@@ -70,14 +75,14 @@ defmodule Mix.Tasks.Addict.Generate.Configs do
       from_email: "no-reply@example.com", # CHANGE THIS
     """
 
-    if use_mailgun do
-      default_configs = default_configs <> """
+    default_configs = if use_mailgun do
+      default_configs <> """
         mailgun_domain: "#{mailgun_domain}",
         mailgun_key: "#{mailgun_api_key}",
         mail_service: :mailgun
       """
     else
-      default_configs = default_configs <> "mail_service: nil"
+      default_configs <> "mail_service: nil"
     end
 
     IO.write(file, default_configs)


### PR DESCRIPTION
This update resolves the following warnings when mix is building addict.

See below output of warnings when running `mix phoenix.server`

```
==> addict
Compiling 29 files (.ex)
warning: the variable "strategies" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/addict/interactors/validate_password.ex:16

warning: the variable "user_schema" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/addict/mix/generate_configs.ex:39

warning: the variable "repo" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/addict/mix/generate_configs.ex:39

warning: the variable "mailgun_domain" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/addict/mix/generate_configs.ex:39

warning: the variable "mailgun_api_key" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/addict/mix/generate_configs.ex:39

warning: the variable "custom_fn" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/addict/controller.ex:129

warning: the variable "default_configs" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/addict/mix/generate_configs.ex:83

warning: the variable "custom_fn" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/addict/controller.ex:139
```
