### PR TITLE
Allow direct assignment of current user to conn

### DIFF
--- a/lib/addict/plugs/authenticated.ex
+++ b/lib/addict/plugs/authenticated.ex
@@ -16,25 +16,25 @@ defmodule Addict.Plugs.Authenticated do
   When called, it will assign `current_user` to `conn`, so it is
   possible to always retrieve the user via `conn.assigns.current_user`.
 
+  If the current_user is already in assigns, the plug does nothing.
+  This allows for creating tests withought creating a session.
+
   In case the user is not logged in, it will redirect the request to
   the Application :addict :not_logged_in_url page. If none is defined, it will
   redirect to `/error`.
   """
+
   def call(conn, _) do
     conn = fetch_session(conn)
-    not_logged_in_url = Addict.Configs.not_logged_in_url || "/login"
-    if is_logged_in(get_session(conn, :current_user)) do
-      assign(conn, :current_user, get_session(conn, :current_user))
-    else
-      conn |> Phoenix.Controller.redirect(to: not_logged_in_url) |> halt
+    session_current_user = get_session(conn, :current_user)
+
+    cond do
+      !is_nil(conn.assigns[:current_user]) -> conn
+      !is_nil(session_current_user) ->
+        assign(conn, :current_user, session_current_user)
+      true ->
+        not_logged_in_url = Addict.Configs.not_logged_in_url || "/login"
+        conn |> Phoenix.Controller.redirect(to: not_logged_in_url) |> halt
     end
   end
-
-  def is_logged_in(user_session) do
-    case user_session do
-      nil -> false
-      _   -> true
-    end
-  end
-
 end

--- a/lib/addict/plugs/authenticated.ex
+++ b/lib/addict/plugs/authenticated.ex
@@ -17,7 +17,7 @@ defmodule Addict.Plugs.Authenticated do
   possible to always retrieve the user via `conn.assigns.current_user`.
 
   If the current_user is already in assigns, the plug does nothing.
-  This allows for creating tests withought creating a session.
+  This allows for creating tests without creating a session.
 
   In case the user is not logged in, it will redirect the request to
   the Application :addict :not_logged_in_url page. If none is defined, it will

--- a/test/plugs/authenticated_test.exs
+++ b/test/plugs/authenticated_test.exs
@@ -41,4 +41,14 @@ defmodule AuthenticatedTest do
     assert conn.status in 300..399
     assert get_resp_header(conn, "location") == ["/login"]
   end
+
+  test "does nothing if no session and user assigned", context do
+    conn = context.conn
+      |> delete_session(:current_user)
+      |> assign(:current_user, "joe")
+
+    conn = Auth.call(conn, @authenticated_opts)
+    assert conn.assigns.current_user == "joe"
+    refute conn.halted
+  end
 end


### PR DESCRIPTION
For applications that use addict, it is often useful to be able to create tests with a logged in user, without creating a session. With this change, if a test sets :current_user in conn.assigns, the plug does nothing, and the test will proceed as if :current_user is logged in.

It is assumed that this would only affect tests, as production application code would not be setting this.

This addresses (at least in part) issue https://github.com/trenpixster/addict/issues/84. Perhaps an example is still needed to better document this feature.