### PR TITLE
Enhanced tests for sample app

### DIFF
--- a/example_app/test/controllers/page_controller_test.exs
+++ b/example_app/test/controllers/page_controller_test.exs
@@ -1,8 +1,19 @@
 defmodule ExampleApp.PageControllerTest do
   use ExampleApp.ConnCase
+  alias ExampleApp.User
 
-  test "GET /", %{conn: conn} do
+  test "logged out GET /", %{conn: conn} do
     conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    assert html_response(conn, 200) =~ "Page available for logged in users only"
+  end
+
+  test "logged in GET /", %{conn: conn} do
+    user = User.changeset(%User{}, %{name: "John",
+                                     email: "john@example.com",
+                                     encrypted_password: "encryped"})
+           |> Repo.insert!
+    Plug.Test.init_test_session(conn, %{current_user: user})
+    conn = get conn, "/"
+    assert html_response(conn, 200) =~ "don't worry about user management"
   end
 end

--- a/example_app/test/controllers/user_controller_test.exs
+++ b/example_app/test/controllers/user_controller_test.exs
@@ -2,59 +2,13 @@ defmodule ExampleApp.UserControllerTest do
   use ExampleApp.ConnCase
 
   alias ExampleApp.User
+
   @valid_attrs %{email: "some content", encrypted_password: "some content", name: "some content"}
   @invalid_attrs %{}
 
   test "lists all entries on index", %{conn: conn} do
     conn = get conn, user_management_path(conn, :index)
     assert html_response(conn, 200) =~ "Listing users"
-  end
-
-  test "renders form for new resources", %{conn: conn} do
-    conn = get conn, user_management_path(conn, :new)
-    assert html_response(conn, 200) =~ "New user"
-  end
-
-  test "creates resource and redirects when data is valid", %{conn: conn} do
-    conn = post conn, user_management_path(conn, :create), user: @valid_attrs
-    assert redirected_to(conn) == user_management_path(conn, :index)
-    assert Repo.get_by(User, @valid_attrs)
-  end
-
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, user_management_path(conn, :create), user: @invalid_attrs
-    assert html_response(conn, 200) =~ "New user"
-  end
-
-  test "shows chosen resource", %{conn: conn} do
-    user = Repo.insert! %User{}
-    conn = get conn, user_management_path(conn, :show, user)
-    assert html_response(conn, 200) =~ "Show user"
-  end
-
-  test "renders page not found when id is nonexistent", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      get conn, user_management_path(conn, :show, -1)
-    end
-  end
-
-  test "renders form for editing chosen resource", %{conn: conn} do
-    user = Repo.insert! %User{}
-    conn = get conn, user_management_path(conn, :edit, user)
-    assert html_response(conn, 200) =~ "Edit user"
-  end
-
-  test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-    user = Repo.insert! %User{}
-    conn = put conn, user_management_path(conn, :update, user), user: @valid_attrs
-    assert redirected_to(conn) == user_management_path(conn, :show, user)
-    assert Repo.get_by(User, @valid_attrs)
-  end
-
-  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    user = Repo.insert! %User{}
-    conn = put conn, user_management_path(conn, :update, user), user: @invalid_attrs
-    assert html_response(conn, 200) =~ "Edit user"
   end
 
   test "deletes chosen resource", %{conn: conn} do


### PR DESCRIPTION
This change is intended to demonstrate how to use addict while testing.

The logged in test use `Plug.Test.init_test_session`

I also removed failing tests for the user_management_controller, for actions that are not implemented in the controller.

Note that I only tested these changes myself in conjunction with #123 